### PR TITLE
Fix code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/lsp/span/parse.go
+++ b/internal/lsp/span/parse.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode/utf8"
+	"math"
 )
 
 // Parse returns the location represented by the input.
@@ -86,8 +87,10 @@ func rstripSuffix(input string) suffix {
 	if last >= 0 && last < len(remains)-1 {
 		number, err := strconv.ParseInt(remains[last+1:], 10, 64)
 		if err == nil {
-			num = int(number)
-			remains = remains[:last+1]
+			if number >= math.MinInt && number <= math.MaxInt {
+				num = int(number)
+				remains = remains[:last+1]
+			}
 		}
 	}
 	// now see if we have a trailing separator


### PR DESCRIPTION
Fixes [https://github.com/guruh46/ntt/security/code-scanning/1](https://github.com/guruh46/ntt/security/code-scanning/1)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseInt` fits within the bounds of the `int` type before converting it. This can be done by checking if the parsed value is within the range of `math.MinInt` and `math.MaxInt` before performing the conversion. If the value is out of bounds, we should handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
