### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
 name: Release
+permissions:
+  contents: read
+  packages: read
+  pull-requests: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/ntt/security/code-scanning/5](https://github.com/guruh46/ntt/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: read` for downloading packages.
- `pull-requests: write` for editing pull requests (if applicable in the MSI upload step).

The `permissions` block will be added at the workflow level to apply to all jobs. If any job requires additional permissions, they can be specified at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- greptile_comment -->

## Greptile Summary

Your free trial has ended. If you'd like to continue receiving code reviews, you can add a payment method here: [https://app.greptile.com/review/github](https://app.greptile.com/review/github).



<!-- /greptile_comment -->