### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Continous Integration
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/ntt/security/code-scanning/4](https://github.com/guruh46/ntt/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Since the workflow only requires read access to the repository contents for testing and linting, we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- greptile_comment -->

## Greptile Summary

Your free trial has ended. If you'd like to continue receiving code reviews, you can add a payment method here: [https://app.greptile.com/review/github](https://app.greptile.com/review/github).



<!-- /greptile_comment -->