### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Tests


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/ntt/security/code-scanning/3](https://github.com/guruh46/ntt/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Based on the provided workflow, the jobs (`test` and `lint`) only require access to the repository contents for tasks like checking out the code and running tests or linting. Therefore, we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- greptile_comment -->

## Greptile Summary

Your free trial has ended. If you'd like to continue receiving code reviews, you can add a payment method here: [https://app.greptile.com/review/github](https://app.greptile.com/review/github).



<!-- /greptile_comment -->