### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 on:
   push:
     tags:


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/ntt/security/code-scanning/2](https://github.com/guruh46/ntt/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow:

1. The `goreleaser` job requires `contents: read` to fetch the repository's contents and `contents: write` to create releases.
2. The `msi` job requires `contents: read` to fetch the repository's contents and `contents: write` to upload MSI files as release assets.

We will add a `permissions` block at the workflow level to apply these permissions to all jobs. If any job requires additional permissions, we will define a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- greptile_comment -->

## Greptile Summary

Your free trial has ended. If you'd like to continue receiving code reviews, you can add a payment method here: [https://app.greptile.com/review/github](https://app.greptile.com/review/github).



<!-- /greptile_comment -->